### PR TITLE
Add missing closing parentheses after cache backend

### DIFF
--- a/clearcache/forms.py
+++ b/clearcache/forms.py
@@ -4,7 +4,7 @@ from django.conf import settings
 
 def get_cache_choices():
     caches = settings.CACHES or {}
-    return [(key, f"{key} ({cache['BACKEND']}") for key, cache in caches.items()]
+    return [(key, f"{key} ({cache['BACKEND']})") for key, cache in caches.items()]
 
 
 class ClearCacheForm(forms.Form):


### PR DESCRIPTION
The entries in dropdown to select the cache to clear are missing a closing parentheses after the cache backend. This patch adds it.